### PR TITLE
Fix vitest config and doc Playwright setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ cp .env.example .env.local
 # edit .env.local and add your project id
 ```
 
+## Testing
+
+Playwright tests rely on a running development server and require
+`NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` to be configured as described above.
+Use `pnpm exec playwright test` to run the browser tests. Unit tests can be
+run with `pnpm test:run`.
+
 
 ## Deploy on Vercel
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'jsdom',
+    environment: 'node',
+    exclude: ['test/playwright/**'],
+    include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- run Vitest in Node environment
- ignore Playwright specs in Vitest
- document how to run tests, including Playwright

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_688a1d7b72c8832d9d75834b96c9e20c